### PR TITLE
Implement truncated logging for FunctionLogger

### DIFF
--- a/Library/PropietaryCode/decorators.py
+++ b/Library/PropietaryCode/decorators.py
@@ -20,6 +20,23 @@ class FunctionLogger:
         """
         self.qc = qc_algorithm_instance
 
+    def _truncate(self, value, limit=10):
+        """Return a truncated representation for large iterables."""
+        try:
+            if isinstance(value, dict):
+                truncated = {k: value[k] for k in list(value)[:limit]}
+                if len(value) > limit:
+                    truncated['...'] = f"{len(value) - limit} more items"
+                return truncated
+            elif isinstance(value, (list, tuple, set)):
+                seq = list(value)[:limit]
+                if len(value) > limit:
+                    seq.append(f"... {len(value) - limit} more")
+                return seq
+        except Exception:
+            pass
+        return value
+
     def log(self, func):
         """
         Method to act as the decorator itself. It logs information about the decorated function's execution.
@@ -32,22 +49,28 @@ class FunctionLogger:
             FunctionLogger.order += 1  # Increment the order of execution
             func_name = func.__name__
 
-            # Log function arguments with their types --> Commented out for clarity and brevity
-            # signature = inspect.signature(func)
-            # bound_args = signature.bind(*args, **kwargs)
-            # bound_args.apply_defaults()
-            # arg_info = {k: (v, type(v).__name__) for k, v in bound_args.arguments.items()}
+            signature = inspect.signature(func)
+            bound_args = signature.bind_partial(*args, **kwargs)
+            bound_args.apply_defaults()
+            arg_info = {}
+            for k, v in bound_args.arguments.items():
+                if k == 'self':
+                    continue
+                arg_info[k] = self._truncate(v)
 
             try:
                 result = func(*args, **kwargs)
                 duration = round(time.time() - start_time, 4)  # Duration in seconds
 
-                # Access QCAlgorithm's Debug method
-                self.qc.Debug(f"ALGO_ORDER: {FunctionLogger.order}, "
-                              f"FUNCTION_ID: {id(func)}, "
-                              f"FUNCTION_NAME: {func_name}, "
-                              # f"PARAMETERS: {arg_info}, "
-                              f"DURATION: {duration}s")
+                log_data = {
+                    'execution_order': FunctionLogger.order,
+                    'function': func_name,
+                    'execution_time': f"{duration} sec",
+                    'args': arg_info,
+                    'result': self._truncate(result)
+                }
+
+                self.qc.Debug(str(log_data))
 
                 return result
 

--- a/Library/PropietaryCode/test_decorators.py
+++ b/Library/PropietaryCode/test_decorators.py
@@ -1,137 +1,42 @@
+import ast
 import unittest
-from unittest.mock import patch, call
-import logging
-from datetime import datetime, timedelta
-from decorators import FunctionLogger  # Replace `mymodule` with the actual module name where the FunctionLogger class is defined
+from PropietaryCode.decorators import FunctionLogger
+
+
+class DummyAlgo:
+    def __init__(self):
+        self.messages = []
+
+    def Debug(self, msg):
+        self.messages.append(msg)
+
+    def Error(self, msg):
+        self.messages.append(msg)
+
 
 class TestFunctionLogger(unittest.TestCase):
-    def setUp(self):
-        # Reset the function counter before each test
-        FunctionLogger.function_counter = 0
+    def test_truncate_list_and_dict(self):
+        algo = DummyAlgo()
+        logger = FunctionLogger(algo)
+        long_list = list(range(20))
+        long_dict = {i: i for i in range(15)}
+        self.assertEqual(len(logger._truncate(long_list)), 11)
+        self.assertEqual(len(logger._truncate(long_dict)), 11)
 
-    @patch('decorators.datetime')  # Patch datetime in the module where FunctionLogger is defined
-    @patch('logging.info')
-    def test_simple_function(self, mock_logger_info, mock_datetime):
-        mock_datetime.now.side_effect = [
-            datetime(2023, 7, 29, 12, 0, 0),
-            datetime(2023, 7, 29, 12, 0, 1)
-        ]
+    def test_logging_truncates_values(self):
+        algo = DummyAlgo()
+        logger = FunctionLogger(algo)
 
-        @FunctionLogger
-        def add(a, b):
-            return a + b
+        @logger.log
+        def example(a):
+            return list(range(15))
 
-        add(2, 3)
+        example(list(range(20)))
+        self.assertTrue(algo.messages)
+        data = ast.literal_eval(algo.messages[0])
+        self.assertEqual(len(data['args']['a']), 11)
+        self.assertEqual(len(data['result']), 11)
 
-        expected_calls = [
-            call('Function add (Index: 0) started at 2023-07-29 12:00:00'),
-            call('Arguments: "2", int, "2", "3", int, "3"'),
-            call('Function add (Index: 0) finished at 2023-07-29 12:00:01, duration: 1.0 seconds')
-        ]
-        mock_logger_info.assert_has_calls(expected_calls, any_order=False)
-
-    @patch('decorators.datetime')  # Patch datetime in the module where FunctionLogger is defined
-    @patch('logging.info')
-    def test_function_with_kwargs(self, mock_logger_info, mock_datetime):
-        mock_datetime.now.side_effect = [
-            datetime(2023, 7, 29, 12, 0, 0),
-            datetime(2023, 7, 29, 12, 0, 1)
-        ]
-
-        @FunctionLogger
-        def greet(greeting, name="World"):
-            return f"{greeting}, {name}!"
-
-        greet(greeting="Hello", name="Alice")
-
-        expected_calls = [
-            call('Function greet (Index: 0) started at 2023-07-29 12:00:00'),
-            call('Arguments: greeting="Hello", str, "Hello", name="Alice", str, "Alice"'),
-            call('Function greet (Index: 0) finished at 2023-07-29 12:00:01, duration: 1.0 seconds')
-        ]
-        mock_logger_info.assert_has_calls(expected_calls, any_order=False)
-
-    @patch('decorators.datetime')  # Patch datetime in the module where FunctionLogger is defined
-    @patch('logging.info')
-    def test_function_with_default_args(self, mock_logger_info, mock_datetime):
-        mock_datetime.now.side_effect = [
-            datetime(2023, 7, 29, 12, 0, 0),
-            datetime(2023, 7, 29, 12, 0, 1)
-        ]
-
-        @FunctionLogger
-        def greet(greeting, name="World"):
-            return f"{greeting}, {name}!"
-
-        greet("Hi")
-
-        expected_calls = [
-            call('Function greet (Index: 0) started at 2023-07-29 12:00:00'),
-            call('Arguments: "Hi", str, "Hi", name="World", str, "World"'),
-            call('Function greet (Index: 0) finished at 2023-07-29 12:00:01, duration: 1.0 seconds')
-        ]
-        mock_logger_info.assert_has_calls(expected_calls, any_order=False)
-
-    @patch('decorators.datetime')  # Patch datetime in the module where FunctionLogger is defined
-    @patch('logging.info')
-    def test_multiple_function_calls(self, mock_logger_info, mock_datetime):
-        mock_datetime.now.side_effect = [
-            datetime(2023, 7, 29, 12, 0, 0),
-            datetime(2023, 7, 29, 12, 0, 1),
-            datetime(2023, 7, 29, 12, 0, 2),
-            datetime(2023, 7, 29, 12, 0, 3),
-            datetime(2023, 7, 29, 12, 0, 4),
-            datetime(2023, 7, 29, 12, 0, 5),
-        ]
-
-        @FunctionLogger
-        def add(a, b):
-            return a + b
-
-        @FunctionLogger
-        def multiply(a, b):
-            return a * b
-
-        add(2, 3)
-        multiply(4, 5)
-        add(5, 7)
-
-        expected_calls = [
-            call('Function add (Index: 0) started at 2023-07-29 12:00:00'),
-            call('Arguments: "2", int, "2", "3", int, "3"'),
-            call('Function add (Index: 0) finished at 2023-07-29 12:00:01, duration: 1.0 seconds'),
-            call('Function multiply (Index: 1) started at 2023-07-29 12:00:02'),
-            call('Arguments: "4", int, "4", "5", int, "5"'),
-            call('Function multiply (Index: 1) finished at 2023-07-29 12:00:03, duration: 1.0 seconds'),
-            call('Function add (Index: 0) started at 2023-07-29 12:00:04'),
-            call('Arguments: "5", int, "5", "7", int, "7"'),
-            call('Function add (Index: 0) finished at 2023-07-29 12:00:05, duration: 1.0 seconds')
-        ]
-        mock_logger_info.assert_has_calls(expected_calls, any_order=False)
-
-    @patch('decorators.datetime')  # Patch datetime in the module where FunctionLogger is defined
-    @patch('logging.info')
-    @patch('logging.error')
-    def test_function_raises_exception(self, mock_logger_error, mock_logger_info, mock_datetime):
-        mock_datetime.now.side_effect = [
-            datetime(2023, 7, 29, 12, 0, 0),
-            datetime(2023, 7, 29, 12, 0, 1)
-        ]
-
-        @FunctionLogger
-        def divide(a, b):
-            return a / b
-
-        with self.assertRaises(ZeroDivisionError):
-            divide(1, 0)
-
-        expected_info_calls = [
-            call('Function divide (Index: 0) started at 2023-07-29 12:00:00'),
-            call('Arguments: "1", int, "1", "0", int, "0"')
-        ]
-        mock_logger_info.assert_has_calls(expected_info_calls, any_order=False)
-
-        mock_logger_error.assert_called_once_with('Function divide (Index: 0) raised an error: division by zero')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- enhance `FunctionLogger` to truncate lists and dicts when logging
- update decorator to log arguments and results in a concise dictionary
- rewrite decorator tests to cover new truncate feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe4bca0a8832c8a1263f3678d17f8