### PR TITLE
refactor: tidy helper scripts

### DIFF
--- a/Scripts/bt_handler.py
+++ b/Scripts/bt_handler.py
@@ -1,134 +1,166 @@
-# Import necessary packages
-import os
-import requests
-import logging
 import argparse
-import yaml
+import base64
+import hashlib
+import json
+import logging
+import os
 import subprocess
 import time
-import hashlib
-import base64
-import json
 
-# Setup logging configuration
+import requests
+import yaml
+
 logging.basicConfig(level=logging.DEBUG)
 
-# Define main function
+
 def main():
-    # Parse command-line arguments
+    """Coordinate download of backtest results and database persistence.
+
+    Steps:
+        1. Parse command-line arguments.
+        2. Retrieve API credentials.
+        3. Generate an API token.
+        4. Download backtest results.
+        5. Inspect and store results.
+    """
     args = parse_arguments()
     backtest_id = args.backtest_id
-
-    # Retrieve API key and user ID from configuration
     api_key, user_id = get_api_key()
-
-    # Generate API token with timestamp and hash
     api_token = generate_api_token(api_key, user_id)
-
-    # Download the results of the backtest
-    results_path, response_data = download_backtest_results(backtest_id, api_token)
-
+    results_path, response_data = download_backtest_results(
+        backtest_id, api_token
+    )
     if results_path:
-        # Log the structure of the API response
         inspect_api_response(response_data)
-
-        # Call the database writer script with the downloaded results
         write_results_to_database(results_path, backtest_id)
 
-# Define function to parse command-line arguments
+
 def parse_arguments():
-    parser = argparse.ArgumentParser(description="Backtest Handler for Downloading Results and Storing in Database")
-    parser.add_argument("backtest_id", type=str, nargs="?", default="0cb0c5993da6a9c89e72f718e610cdef", help="ID of the backtest to handle")
+    """Return command-line arguments for the script."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backtest Handler for Downloading Results and Storing in Database"
+        )
+    )
+    parser.add_argument(
+        "backtest_id",
+        type=str,
+        nargs="?",
+        default="0cb0c5993da6a9c89e72f718e610cdef",
+        help="ID of the backtest to handle",
+    )
     return parser.parse_args()
 
-# Define function to retrieve API key and user ID from UserConfig.yaml
+
 def get_api_key():
+    """Load API key and user ID from Resources/UserConfig.yaml.
+
+    Pseudocode:
+        resolve configuration path relative to script
+        open YAML file and parse
+        extract LOGIN_API_KEY and USER_ID
+        return credentials
+    """
     try:
-        # Resolve absolute path to UserConfig.yaml relative to script location
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        config_path = os.path.join(script_dir, "..", "Resources", "UserConfig.yaml")
+        config_path = os.path.join(
+            script_dir, "..", "Resources", "UserConfig.yaml"
+        )
         with open(config_path, "r") as file:
             config = yaml.safe_load(file)
             defaults = config.get("defaults", {})
             api_key = defaults.get("LOGIN_API_KEY")
             user_id = defaults.get("USER_ID")
             if not api_key or not user_id:
-                raise ValueError("API key or User ID not found in configuration file.")
-            logging.info("API key and User ID successfully retrieved from configuration.")
+                raise ValueError(
+                    "API key or User ID not found in configuration file."
+                )
+            logging.info("API key and User ID successfully retrieved.")
             return api_key, user_id
     except Exception as e:
         logging.error(f"Failed to retrieve API key: {e}")
         raise
 
-# Define function to generate API token with timestamp and hash
+
 def generate_api_token(api_key, user_id):
+    """Create encoded token for QuantConnect API.
+
+    Pseudocode:
+        get current timestamp
+        combine API key and timestamp then hash with SHA256
+        base64 encode user ID and hashed token
+        return token and timestamp
+    """
     try:
-        # Get the current timestamp
         timestamp = str(int(time.time()))
-
-        # Combine the API key and timestamp, then hash them using SHA256
         time_stamped_token = f"{api_key}:{timestamp}"
-        hashed_token = hashlib.sha256(time_stamped_token.encode('utf-8')).hexdigest()
-
-        # Format the authentication string and encode it in base64
+        hashed_token = hashlib.sha256(
+            time_stamped_token.encode("utf-8")
+        ).hexdigest()
         authentication = f"{user_id}:{hashed_token}"
-        api_token = base64.b64encode(authentication.encode('utf-8')).decode('ascii')
-
-        # Log the generated token for debugging (masked for security)
-        logging.debug(f"Generated token hash: {hashed_token[:6]}... (truncated for security)")
+        api_token = base64.b64encode(
+            authentication.encode("utf-8")
+        ).decode("ascii")
+        logging.debug(
+            f"Generated token hash: {hashed_token[:6]}... "
+            "(truncated for security)"
+        )
         logging.debug(f"Generated timestamp: {timestamp}")
-
-        # Return the encoded API token and timestamp
         logging.info("API token successfully generated.")
         return {"api_token": api_token, "timestamp": timestamp}
     except Exception as e:
         logging.error(f"Failed to generate API token: {e}")
         raise
 
-# Define function to download backtest results via QuantConnect API
+
 def download_backtest_results(backtest_id, api_token):
+    """Fetch backtest results via QuantConnect API.
+
+    Pseudocode:
+        create results directory
+        build API request headers and payload
+        post request to API endpoint
+        write JSON response to file
+        return file path and response data
+    """
     try:
-        # Resolve results directory relative to the Scripts folder
         script_dir = os.path.dirname(os.path.abspath(__file__))
         results_dir = os.path.join(script_dir, "backtest_results")
         os.makedirs(results_dir, exist_ok=True)
         results_path = os.path.join(results_dir, f"{backtest_id}.json")
 
-        # Define the API endpoint and headers
         api_url = "https://www.quantconnect.com/api/v2/backtests/read"
         headers = {
             "Authorization": f"Basic {api_token['api_token']}",
-            "Timestamp": api_token['timestamp']
+            "Timestamp": api_token["timestamp"],
         }
-
-        # Log headers for debugging
         logging.debug(f"Request headers: {headers}")
 
-        # Make the API request
-        logging.info(f"Fetching results for backtest ID: {backtest_id} from QuantConnect API.")
+        logging.info(
+            f"Fetching results for backtest ID: {backtest_id} from API."
+        )
         payload = {
-            "projectId": 0,  # Replace with the actual project ID
-            "backtestId": backtest_id
+            "projectId": 0,  # Replace with actual project ID
+            "backtestId": backtest_id,
         }
         response = requests.post(api_url, headers=headers, json=payload)
         response.raise_for_status()
-
-        # Parse the JSON response
         response_data = response.json()
 
-        # Save the results to a JSON file
         with open(results_path, "w") as file:
             json.dump(response_data, file, indent=4)
 
         logging.info(f"Backtest results downloaded to: {results_path}")
         return results_path, response_data
-
     except requests.RequestException as e:
-        logging.error(f"Failed to fetch backtest results for ID {backtest_id}: {e}")
+        logging.error(
+            f"Failed to fetch backtest results for ID {backtest_id}: {e}"
+        )
         return None, None
 
-# Define function to inspect the structure of the API response
+
 def inspect_api_response(response_data):
+    """Log the structure of the API response for debugging."""
     try:
         if response_data:
             logging.info("Inspecting API response structure...")
@@ -138,24 +170,35 @@ def inspect_api_response(response_data):
     except Exception as e:
         logging.error(f"Failed to inspect API response: {e}")
 
-# Define function to call the database writer script
+
 def write_results_to_database(results_path, backtest_id):
+    """Invoke db_operator script to store results in database.
+
+    Pseudocode:
+        resolve path to db_operator.py
+        build command with results path and backtest ID
+        run command with subprocess
+    """
     try:
-        # Resolve absolute path to the db_operator script relative to script location
         script_dir = os.path.dirname(os.path.abspath(__file__))
         database_writer_script = os.path.join(script_dir, "db_operator.py")
-
-        # Construct the command to call the database writer script
-        db_write_command = f"python {database_writer_script} --results-path {results_path} --backtest-id {backtest_id}"
-
-        logging.info(f"Calling database writer script for backtest ID: {backtest_id}")
+        db_write_command = (
+            f"python {database_writer_script} "
+            f"--results-path {results_path} --backtest-id {backtest_id}"
+        )
+        logging.info(
+            f"Calling database writer script for backtest ID: {backtest_id}"
+        )
         subprocess.run(db_write_command, shell=True, check=True)
-
-        logging.info(f"Results successfully written to the database for backtest ID: {backtest_id}")
-
+        logging.info(
+            "Results successfully written to the database for "
+            f"backtest ID: {backtest_id}"
+        )
     except subprocess.CalledProcessError as e:
-        logging.error(f"Failed to write results to the database for ID {backtest_id}: {e}")
+        logging.error(
+            f"Failed to write results to the database for ID {backtest_id}: {e}"
+        )
 
-# Call the main function if the script is executed
+
 if __name__ == "__main__":
     main()

--- a/Scripts/class_helper.py
+++ b/Scripts/class_helper.py
@@ -1,16 +1,29 @@
 import os
 
+
 def find_pyi_files(root_dir):
+    """Return a list of ``.pyi`` files within ``root_dir``.
+
+    Pseudocode:
+        initialize empty list for results
+        walk through directories under ``root_dir``
+        for each file encountered:
+            if file extension is ``.pyi``:
+                append absolute path to results list
+        return collected paths
+    """
     pyi_files = []
     for dirpath, _, filenames in os.walk(root_dir):
         for file in filenames:
-            if file.endswith('.pyi'):
+            if file.endswith(".pyi"):
                 pyi_files.append(os.path.join(dirpath, file))
     return pyi_files
 
-# Example usage
+
 if __name__ == "__main__":
-    root_directory = "C:/Users/bryan/PycharmProjects/QuantConnectProject/.venv/Lib/site-packages/QuantConnect"  # or replace with full path like "C:/Users/bryan/PyCharmProjects/QuantConnectProject"
-    results = find_pyi_files(root_directory)
-    for path in results:
+    ROOT_DIRECTORY = (
+        "C:/Users/bryan/PycharmProjects/QuantConnectProject/.venv/"
+        "Lib/site-packages/QuantConnect"
+    )
+    for path in find_pyi_files(ROOT_DIRECTORY):
         print(path)


### PR DESCRIPTION
## Summary
- clean `class_helper` and add pseudocode for locating `.pyi` stubs
- streamline `bt_handler` with docstrings, organized imports, and stepwise pseudocode

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'AlgorithmImports')*

------
https://chatgpt.com/codex/tasks/task_e_6890e5a7d26c832c83068fbc17f03974